### PR TITLE
Add tables support for markdown

### DIFF
--- a/run.py
+++ b/run.py
@@ -227,7 +227,7 @@ def GetReadMe(path):
         ext='Text'
         readme,_,i=has_item(path,'README.txt')
     if readme!=False:
-        readme=markdown.markdown(readme)
+        readme=markdown.markdown(readme, extensions=['tables'])
     return readme,ext
 
 
@@ -245,7 +245,7 @@ def GetHead(path):
         ext='Text'
         head,_,i=has_item(path,'HEAD.txt')
     if head!=False:
-        head=markdown.markdown(head)
+        head=markdown.markdown(head, extensions=['tables'])
     return head,ext
 
 


### PR DESCRIPTION
md 里 tables 的语法默认被 py 的这个库关了？但是比较常用，所以加上了。

check: https://python-markdown.github.io/extensions/tables/